### PR TITLE
Update open tracing dependencies. Remove sql related dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-jdbc-client</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>

--- a/vertx-opentracing/pom.xml
+++ b/vertx-opentracing/pom.xml
@@ -36,18 +36,14 @@
     <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
-      <version>0.32.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-mock</artifactId>
-      <version>0.31.0</version>
+      <version>0.33.0</version>
     </dependency>
+
   </dependencies>
 </project>

--- a/vertx-zipkin/pom.xml
+++ b/vertx-zipkin/pom.xml
@@ -45,12 +45,6 @@
       <version>${zipkin.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.hsqldb</groupId>
-      <artifactId>hsqldb</artifactId>
-      <version>2.3.4</version>
-    </dependency>
-
-    <dependency>
       <groupId>io.zipkin.zipkin2</groupId>
       <artifactId>zipkin-junit</artifactId>
       <version>2.12.1</version>


### PR DESCRIPTION
As mentioned in #2, I updated the opentracing dependencies, including Jaeger. Likewise I removed the SQL related dependencies.