### PR TITLE
Add opentracing example to set span

### DIFF
--- a/vertx-opentracing/src/main/asciidoc/index.adoc
+++ b/vertx-opentracing/src/main/asciidoc/index.adoc
@@ -17,3 +17,18 @@ over the configuration.
 ----
 {@link examples.OpenTracingExamples#ex2}
 ----
+
+After the Tracer has been configured, Vert.x may inject _spans_ into existing traces for
+some API calls, such as HTTP client or server requests. A trace that starts from a server
+call will be automatically created by Vert.x.
+
+However, to initiate a trace for a client call, you need to create it first and make Vert.x
+aware of it by using `OpenTracingUtil.setSpan`:
+
+[source,$lang]
+----
+{@link examples.OpenTracingExamples#ex3}
+----
+
+In an HTTP scenario between two Vert.x services, a span will be created client-side, then
+the trace context will be propagated server-side and another span will be added to the trace.

--- a/vertx-opentracing/src/main/java/examples/OpenTracingExamples.java
+++ b/vertx-opentracing/src/main/java/examples/OpenTracingExamples.java
@@ -1,10 +1,12 @@
 package examples;
 
+import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.docgen.Source;
 import io.vertx.tracing.opentracing.OpenTracingOptions;
+import io.vertx.tracing.opentracing.OpenTracingUtil;
 
 @Source
 public class OpenTracingExamples {
@@ -23,5 +25,14 @@ public class OpenTracingExamples {
         new OpenTracingOptions(tracer)
       )
     );
+  }
+
+  public void ex3(Tracer tracer) {
+    Span span = tracer.buildSpan("my-operation")
+      .withTag("some-key", "some-value")
+      .start();
+    OpenTracingUtil.setSpan(span);
+    // Do something, e.g. client request
+    span.finish();
   }
 }


### PR DESCRIPTION
This information will help to understand what vert.x expects, in particular ACTIVE_SPAN has to be set in order to have spans injected in client requests.

PS: I haven't used the Zipkin implementation already, but I can amend this PR if someone tells me the equivalent thing to do.