### PR TITLE
Implement DataObject requirements in OpenTracingOptions and ZipkinTracingOptions

### DIFF
--- a/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingOptions.java
+++ b/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingOptions.java
@@ -20,15 +20,29 @@ public class OpenTracingOptions extends TracingOptions {
 
   private Tracer tracer;
 
+  public OpenTracingOptions() {
+  }
+
   public OpenTracingOptions(Tracer tracer) {
     this.tracer = tracer;
   }
 
-  public OpenTracingOptions() {
+  public OpenTracingOptions(OpenTracingOptions other) {
+    tracer = other.tracer;
   }
 
   public OpenTracingOptions(JsonObject json) {
     super(json);
+  }
+
+  @Override
+  public OpenTracingOptions copy() {
+    return new OpenTracingOptions(this);
+  }
+
+  // Visible for testing
+  Tracer getTracer() {
+    return tracer;
   }
 
   io.vertx.core.spi.tracing.VertxTracer<?, ?> buildTracer() {

--- a/vertx-opentracing/src/test/java/io/vertx/tracing/opentracing/OpenTracingOptionsTest.java
+++ b/vertx-opentracing/src/test/java/io/vertx/tracing/opentracing/OpenTracingOptionsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.tracing.opentracing;
+
+import io.opentracing.mock.MockTracer;
+import io.vertx.core.tracing.TracingOptions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class OpenTracingOptionsTest {
+
+  @Test
+  public void testCopy() {
+    MockTracer tracer = new MockTracer();
+    TracingOptions options = new OpenTracingOptions(tracer);
+    TracingOptions copy = options.copy();
+    assertTrue(copy instanceof OpenTracingOptions);
+    OpenTracingOptions other = (OpenTracingOptions) copy;
+    assertSame(tracer, other.getTracer());
+  }
+}

--- a/vertx-zipkin/src/main/generated/io/vertx/tracing/zipkin/HttpSenderOptionsConverter.java
+++ b/vertx-zipkin/src/main/generated/io/vertx/tracing/zipkin/HttpSenderOptionsConverter.java
@@ -1,0 +1,37 @@
+package io.vertx.tracing.zipkin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.tracing.zipkin.HttpSenderOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.tracing.zipkin.HttpSenderOptions} original class using Vert.x codegen.
+ */
+public class HttpSenderOptionsConverter {
+
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, HttpSenderOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "senderEndpoint":
+          if (member.getValue() instanceof String) {
+            obj.setSenderEndpoint((String)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(HttpSenderOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(HttpSenderOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getSenderEndpoint() != null) {
+      json.put("senderEndpoint", obj.getSenderEndpoint());
+    }
+  }
+}

--- a/vertx-zipkin/src/main/generated/io/vertx/tracing/zipkin/ZipkinTracingOptionsConverter.java
+++ b/vertx-zipkin/src/main/generated/io/vertx/tracing/zipkin/ZipkinTracingOptionsConverter.java
@@ -1,0 +1,51 @@
+package io.vertx.tracing.zipkin;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.impl.JsonUtil;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Converter and mapper for {@link io.vertx.tracing.zipkin.ZipkinTracingOptions}.
+ * NOTE: This class has been automatically generated from the {@link io.vertx.tracing.zipkin.ZipkinTracingOptions} original class using Vert.x codegen.
+ */
+public class ZipkinTracingOptionsConverter {
+
+
+   static void fromJson(Iterable<java.util.Map.Entry<String, Object>> json, ZipkinTracingOptions obj) {
+    for (java.util.Map.Entry<String, Object> member : json) {
+      switch (member.getKey()) {
+        case "senderOptions":
+          if (member.getValue() instanceof JsonObject) {
+            obj.setSenderOptions(new io.vertx.tracing.zipkin.HttpSenderOptions((io.vertx.core.json.JsonObject)member.getValue()));
+          }
+          break;
+        case "serviceName":
+          if (member.getValue() instanceof String) {
+            obj.setServiceName((String)member.getValue());
+          }
+          break;
+        case "supportsJoin":
+          if (member.getValue() instanceof Boolean) {
+            obj.setSupportsJoin((Boolean)member.getValue());
+          }
+          break;
+      }
+    }
+  }
+
+   static void toJson(ZipkinTracingOptions obj, JsonObject json) {
+    toJson(obj, json.getMap());
+  }
+
+   static void toJson(ZipkinTracingOptions obj, java.util.Map<String, Object> json) {
+    if (obj.getSenderOptions() != null) {
+      json.put("senderOptions", obj.getSenderOptions().toJson());
+    }
+    if (obj.getServiceName() != null) {
+      json.put("serviceName", obj.getServiceName());
+    }
+    json.put("supportsJoin", obj.isSupportsJoin());
+  }
+}

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/HttpSenderOptions.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/HttpSenderOptions.java
@@ -16,16 +16,7 @@ import io.vertx.core.http.Http2Settings;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.net.JdkSSLEngineOptions;
-import io.vertx.core.net.JksOptions;
-import io.vertx.core.net.KeyCertOptions;
-import io.vertx.core.net.OpenSSLEngineOptions;
-import io.vertx.core.net.PemKeyCertOptions;
-import io.vertx.core.net.PemTrustOptions;
-import io.vertx.core.net.PfxOptions;
-import io.vertx.core.net.ProxyOptions;
-import io.vertx.core.net.SSLEngineOptions;
-import io.vertx.core.net.TrustOptions;
+import io.vertx.core.net.*;
 
 import java.util.List;
 import java.util.Set;
@@ -34,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Options for reporting to a Zipkin server configured by default to {@code http://localhost:9411/api/v2/spans}.
  */
-@DataObject
+@DataObject(generateConverter = true, publicConverter = false)
 public class HttpSenderOptions extends HttpClientOptions {
 
   public static final String DEFAULT_SENDER_ENDPOINT = "http://localhost:9411/api/v2/spans";
@@ -52,8 +43,16 @@ public class HttpSenderOptions extends HttpClientOptions {
     setTryUseCompression(true);
   }
 
+  public HttpSenderOptions(HttpSenderOptions other) {
+    super(other);
+    init();
+    this.senderEndpoint = other.senderEndpoint;
+  }
+
   public HttpSenderOptions(JsonObject json) {
     super(json);
+    init();
+    HttpSenderOptionsConverter.fromJson(json, this);
   }
 
   /**

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracingOptions.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracingOptions.java
@@ -14,7 +14,6 @@ import brave.Tracing;
 import brave.http.HttpTracing;
 import brave.sampler.Sampler;
 import io.vertx.codegen.annotations.DataObject;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingOptions;
@@ -24,7 +23,7 @@ import zipkin2.reporter.Sender;
 import java.io.IOException;
 import java.util.Objects;
 
-@DataObject
+@DataObject(generateConverter = true, publicConverter = false)
 public class ZipkinTracingOptions extends TracingOptions {
 
   public static final String DEFAULT_SERVICE_NAME = "a-service";
@@ -46,8 +45,21 @@ public class ZipkinTracingOptions extends TracingOptions {
   public ZipkinTracingOptions() {
   }
 
+  public ZipkinTracingOptions(ZipkinTracingOptions other) {
+    this.serviceName = other.serviceName;
+    this.supportsJoin = other.supportsJoin;
+    this.senderOptions = other.senderOptions == null ? null : new HttpSenderOptions(other.senderOptions);
+    this.httpTracing = other.httpTracing == null ? null : other.httpTracing.toBuilder().build();
+  }
+
   public ZipkinTracingOptions(JsonObject json) {
     super(json);
+    ZipkinTracingOptionsConverter.fromJson(json, this);
+  }
+
+  @Override
+  public ZipkinTracingOptions copy() {
+    return new ZipkinTracingOptions(this);
   }
 
   /**

--- a/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinTracingOptionsTest.java
+++ b/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinTracingOptionsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.tracing.zipkin;
+
+import io.vertx.core.tracing.TracingOptions;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ZipkinTracingOptionsTest {
+
+  @Test
+  public void testCopy() {
+    TracingOptions options = new ZipkinTracingOptions().setServiceName("foo");
+    TracingOptions copy = options.copy();
+    assertTrue(copy instanceof ZipkinTracingOptions);
+    ZipkinTracingOptions other = (ZipkinTracingOptions) copy;
+    assertEquals("foo", other.getServiceName());
+  }
+}


### PR DESCRIPTION
One or more of these requirements were not implemented:

- no-arg constructor
- copy constructor
- json copy

Also, TracingOptions subclasses should override the copy method: it is used in VertxOptions copy constructor.

Fixes eclipse-vertx/vert.x#3829