### PR TITLE
fix/opentelemetry documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,12 @@ image:https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style
 
 This is the repository for Vert.x tracing SPI implementations.
 
+== OpenTelemetry
+
+Provides integration https://opentelemetry.io/[OpenTelemetry]
+
+- https://vertx.io/docs/vertx-opentelemetry/java/[website docs]
+
 == OpenTracing
 
 Provides integration https://opentracing.io[OpenTracing]

--- a/vertx-opentelemetry/src/main/asciidoc/index.adoc
+++ b/vertx-opentelemetry/src/main/asciidoc/index.adoc
@@ -15,6 +15,14 @@ over the configuration.
 {@link examples.OpenTelemetryExamples#ex2}
 ----
 
+If you only add this library, it will give you access to OpenTelemetry API with a default `noop` Tracer,
+which gives dummy values (all zeroes) for trace and span ids. The OpenTelemetry SDK is needed to get proper values.
+
+[source,$lang]
+----
+{@link examples.OpenTelemetryExamples#ex7}
+----
+
 == Tracing policy
 
 The tracing policy defines the behavior of a component when tracing is enabled:

--- a/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
+++ b/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
@@ -56,4 +56,14 @@ public class OpenTelemetryExamples {
     DeliveryOptions options = new DeliveryOptions().setTracingPolicy(TracingPolicy.ALWAYS);
     vertx.eventBus().send("the-address", "foo", options);
   }
+
+  public void ex7(VertxOptions vertxOptions) {
+    SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder().build();
+    OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+      .setTracerProvider(sdkTracerProvider)
+      .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
+      .buildAndRegisterGlobal();
+
+    vertxOptions.setTracingOptions(new OpenTelemetryOptions(openTelemetry));
+  }
 }


### PR DESCRIPTION
Motivation:

OpenTelemetry documentation is very thin. Added more documentation and code example to show one approach.