### PR TITLE
Added default instance factory for OpenTracing and Zipkin

### DIFF
--- a/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingOptions.java
+++ b/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingOptions.java
@@ -21,18 +21,22 @@ public class OpenTracingOptions extends TracingOptions {
   private Tracer tracer;
 
   public OpenTracingOptions() {
+    this.setFactory(OpenTracingTracerFactory.INSTANCE);
   }
 
   public OpenTracingOptions(Tracer tracer) {
     this.tracer = tracer;
+    this.setFactory(OpenTracingTracerFactory.INSTANCE);
   }
 
   public OpenTracingOptions(OpenTracingOptions other) {
     tracer = other.tracer;
+    this.setFactory(OpenTracingTracerFactory.INSTANCE);
   }
 
   public OpenTracingOptions(JsonObject json) {
     super(json);
+    this.setFactory(OpenTracingTracerFactory.INSTANCE);
   }
 
   @Override

--- a/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingTracerFactory.java
+++ b/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingTracerFactory.java
@@ -17,6 +17,8 @@ import io.vertx.core.tracing.TracingOptions;
 
 public class OpenTracingTracerFactory implements VertxTracerFactory {
 
+  static final OpenTracingTracerFactory INSTANCE = new OpenTracingTracerFactory();
+
   @Override
   public VertxTracer tracer(TracingOptions options) {
     OpenTracingOptions openTracingOptions;

--- a/vertx-opentracing/src/test/java/io/vertx/tracing/opentracing/OpenTracingOptionsTest.java
+++ b/vertx-opentracing/src/test/java/io/vertx/tracing/opentracing/OpenTracingOptionsTest.java
@@ -12,9 +12,13 @@
 package io.vertx.tracing.opentracing;
 
 import io.opentracing.mock.MockTracer;
+import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.tracing.TracingOptions;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
@@ -28,5 +32,20 @@ public class OpenTracingOptionsTest {
     assertTrue(copy instanceof OpenTracingOptions);
     OpenTracingOptions other = (OpenTracingOptions) copy;
     assertSame(tracer, other.getTracer());
+  }
+
+  @Test
+  public void testDefaultFactory() {
+    TracingOptions options = new OpenTracingOptions();
+    assertNotNull(options.getFactory());
+    assertEquals(OpenTracingTracerFactory.INSTANCE, options.getFactory());
+  }
+
+  @Test
+  public void testFactory() {
+    TracingOptions options = new OpenTracingOptions().setFactory(VertxTracerFactory.NOOP);
+    assertNotNull(options.getFactory());
+    assertNotEquals(OpenTracingTracerFactory.INSTANCE, options.getFactory());
+    assertEquals(VertxTracerFactory.NOOP, options.getFactory());
   }
 }

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracerFactory.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracerFactory.java
@@ -16,6 +16,8 @@ import io.vertx.core.tracing.TracingOptions;
 
 public class ZipkinTracerFactory implements VertxTracerFactory {
 
+  static final ZipkinTracerFactory INSTANCE = new ZipkinTracerFactory();
+
   @Override
   public ZipkinTracer tracer(TracingOptions options) {
     ZipkinTracingOptions zipkinOptions;

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracingOptions.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracingOptions.java
@@ -36,13 +36,16 @@ public class ZipkinTracingOptions extends TracingOptions {
 
   public ZipkinTracingOptions(HttpTracing httpTracing) {
     this.httpTracing = httpTracing;
+    this.setFactory(ZipkinTracerFactory.INSTANCE);
   }
 
   public ZipkinTracingOptions(Tracing tracing) {
     this.httpTracing = HttpTracing.newBuilder(tracing).build();
+    this.setFactory(ZipkinTracerFactory.INSTANCE);
   }
 
   public ZipkinTracingOptions() {
+    this.setFactory(ZipkinTracerFactory.INSTANCE);
   }
 
   public ZipkinTracingOptions(ZipkinTracingOptions other) {
@@ -50,11 +53,13 @@ public class ZipkinTracingOptions extends TracingOptions {
     this.supportsJoin = other.supportsJoin;
     this.senderOptions = other.senderOptions == null ? null : new HttpSenderOptions(other.senderOptions);
     this.httpTracing = other.httpTracing == null ? null : other.httpTracing.toBuilder().build();
+    this.setFactory(ZipkinTracerFactory.INSTANCE);
   }
 
   public ZipkinTracingOptions(JsonObject json) {
     super(json);
     ZipkinTracingOptionsConverter.fromJson(json, this);
+    this.setFactory(ZipkinTracerFactory.INSTANCE);
   }
 
   @Override

--- a/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinTracingOptionsTest.java
+++ b/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinTracingOptionsTest.java
@@ -11,10 +11,13 @@
 
 package io.vertx.tracing.zipkin;
 
+import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.tracing.TracingOptions;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class ZipkinTracingOptionsTest {
@@ -36,5 +39,20 @@ public class ZipkinTracingOptionsTest {
     ZipkinTracer tracer = factory.tracer(new TracingOptions(options.toJson()));
     VertxSender sender = tracer.sender();
     assertEquals(senderOptions.toJson(), sender.options().toJson());
+  }
+
+  @Test
+  public void testDefaultFactory() {
+    TracingOptions options = new ZipkinTracingOptions();
+    assertNotNull(options.getFactory());
+    assertEquals(ZipkinTracerFactory.INSTANCE, options.getFactory());
+  }
+
+  @Test
+  public void testFactory() {
+    TracingOptions options = new ZipkinTracingOptions().setFactory(VertxTracerFactory.NOOP);
+    assertNotNull(options.getFactory());
+    assertNotEquals(ZipkinTracerFactory.INSTANCE, options.getFactory());
+    assertEquals(VertxTracerFactory.NOOP, options.getFactory());
   }
 }


### PR DESCRIPTION
This PR fixes #44 in order to set a default factory for OpenTracing and Zipkin when options are created, as already happens with OpenTelemetry.