### PR TITLE
Bumped OpenTelemetry to latest 1.18.0

### DIFF
--- a/vertx-opentelemetry/pom.xml
+++ b/vertx-opentelemetry/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <doc.skip>false</doc.skip>
-    <opentelemetry.version>1.13.0</opentelemetry.version>
+    <opentelemetry.version>1.18.0</opentelemetry.version>
     <assertj.version>3.22.0</assertj.version>
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <mokito.junit.jupiter.version>4.5.1</mokito.junit.jupiter.version>


### PR DESCRIPTION
Starting from OpenTelemetry 1.17.0, they introduced an API change breaking backward compatibility.
We faced this problem here in the Strimzi bridge https://github.com/strimzi/strimzi-kafka-bridge/pull/678 and needed to override one of the Vert.x dependencies.
This PR bumps the OpenTelemetry version used by the Vert.x component for future releases.