### PR TITLE
Fix/vertx span parenting (4.x)

### DIFF
--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
@@ -55,7 +55,7 @@ class OpenTelemetryTracer implements VertxTracer<Span, Span> {
       return null;
     }
 
-    io.opentelemetry.context.Context tracingContext = propagators.getTextMapPropagator().extract(io.opentelemetry.context.Context.root(), headers, getter);
+    io.opentelemetry.context.Context tracingContext = propagators.getTextMapPropagator().extract(io.opentelemetry.context.Context.current(), headers, getter);
 
     // If no span, and policy is PROPAGATE, then don't create the span
     if (Span.fromContextOrNull(tracingContext) == null && TracingPolicy.PROPAGATE.equals(policy)) {


### PR DESCRIPTION
Relates to: https://github.com/eclipse-vertx/vertx-tracing/pull/56

Motivation:

When running a vert.x application under the opentelemetry java agent, it's possible for an ongoing span to exist in the agent's current Context. Under the current implementation, this span would be missed by the vert.x OpenTelemetryTracer as it's consulting the root context only, rather than any ongoing context.

I've been able to reproduce the issue in the included unit test.

The change here is to have the OpenTelemetryTracer consult the current context instead of the root. Note that if no current context exists, then the root will be returned anyway.