### PR TITLE
OpenTelemetry: report tag names that conform to the specification

### DIFF
--- a/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/EventBusTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/EventBusTest.java
@@ -92,6 +92,8 @@ public class EventBusTest {
             .isEqualTo("send");
           assertThat(data.getAttributes().get(AttributeKey.stringKey("message_bus.destination")))
             .isEqualTo(ADDRESS);
+          assertThat(data.getAttributes().get(AttributeKey.stringKey("messaging.destination.name")))
+            .isEqualTo(ADDRESS);
         }
       }
       if (count == expected) {
@@ -154,6 +156,8 @@ public class EventBusTest {
                       assertThat(operationName)
                         .isEqualTo("publish");
                       assertThat(data.getAttributes().get(AttributeKey.stringKey("message_bus.destination")))
+                        .isEqualTo(ADDRESS);
+                      assertThat(data.getAttributes().get(AttributeKey.stringKey("messaging.destination.name")))
                         .isEqualTo(ADDRESS);
                     }
                   }


### PR DESCRIPTION
Spec: https://opentelemetry.io/docs/specs/otel/

For backwards compatibility, existing attributes are still reported