### PR TITLE
OpenTelemetry: fallback to default storage when not on a Vert.x thread

### DIFF
--- a/vertx-opentelemetry/src/main/asciidoc/index.adoc
+++ b/vertx-opentelemetry/src/main/asciidoc/index.adoc
@@ -23,6 +23,19 @@ which gives dummy values (all zeroes) for trace and span ids. The OpenTelemetry 
 {@link examples.OpenTelemetryExamples#ex7}
 ----
 
+[NOTE]
+====
+This project provides an OpenTelemetry `ContextStorageProvider` that uses the Vert.x {@link io.vertx.core.Context} when invoked on a Vert.x thread.
+Otherwise, it fallbacks to the default storage.
+
+If several `ContextStorageProvider` implementations are present on the classpath, you can force OpenTelemetry to select the Vert.x one:
+
+[source]
+----
+-Dio.opentelemetry.context.contextStorageProvider=io.vertx.tracing.opentelemetry.VertxContextStorageProvider
+----
+====
+
 == Tracing policy
 
 The tracing policy defines the behavior of a component when tracing is enabled:

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryOptions.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -12,8 +12,6 @@ package io.vertx.tracing.opentelemetry;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -38,7 +36,7 @@ public class OpenTelemetryOptions extends TracingOptions {
     this.setFactory(OpenTelemetryTracingFactory.INSTANCE);
   }
 
-  VertxTracer<Span, Span> buildTracer() {
+  VertxTracer<Operation, Operation> buildTracer() {
     if (openTelemetry != null) {
       return new OpenTelemetryTracer(openTelemetry);
     } else {

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -10,8 +10,6 @@
  */
 package io.vertx.tracing.opentelemetry;
 
-import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.context.Scope;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -22,7 +20,7 @@ public class OpenTelemetryTracingFactory implements VertxTracerFactory {
   static final OpenTelemetryTracingFactory INSTANCE = new OpenTelemetryTracingFactory();
 
   @Override
-  public VertxTracer<Span, Span> tracer(final TracingOptions options) {
+  public VertxTracer<?, ?> tracer(final TracingOptions options) {
     OpenTelemetryOptions openTelemetryOptions;
     if (options instanceof OpenTelemetryOptions) {
       openTelemetryOptions = (OpenTelemetryOptions) options;

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/Operation.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/Operation.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package io.vertx.tracing.opentelemetry;
+
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Scope;
+
+import java.util.Objects;
+
+final class Operation {
+
+  private final Span span;
+  private final Scope scope;
+
+  Operation(Span span, Scope scope) {
+    this.span = Objects.requireNonNull(span);
+    this.scope = Objects.requireNonNull(scope);
+  }
+
+  public Span span() {
+    return span;
+  }
+
+  public Scope scope() {
+    return scope;
+  }
+}

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/VertxContextStorageProvider.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/VertxContextStorageProvider.java
@@ -1,14 +1,25 @@
+/*
+ * Copyright (c) 2011-2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
 package io.vertx.tracing.opentelemetry;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.ContextStorage;
 import io.opentelemetry.context.ContextStorageProvider;
 import io.opentelemetry.context.Scope;
-import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
 
 public class VertxContextStorageProvider implements ContextStorageProvider {
 
-  static String ACTIVE_CONTEXT = "tracing.context";
+  private static final Object ACTIVE_CONTEXT = new Object();
 
   @Override
   public ContextStorage get() {
@@ -20,7 +31,11 @@ public class VertxContextStorageProvider implements ContextStorageProvider {
 
     @Override
     public Scope attach(Context toAttach) {
-      return attach(Vertx.currentContext(), toAttach);
+      ContextInternal current = ContextInternal.current();
+      if (current == null) {
+        return ContextStorage.defaultStorage().attach(toAttach);
+      }
+      return attach(current, toAttach);
     }
 
     public Scope attach(io.vertx.core.Context vertxCtx, Context toAttach) {
@@ -40,9 +55,9 @@ public class VertxContextStorageProvider implements ContextStorageProvider {
 
     @Override
     public Context current() {
-      io.vertx.core.Context vertxCtx = Vertx.currentContext();
+      ContextInternal vertxCtx = ContextInternal.current();
       if (vertxCtx == null) {
-        return null;
+        return ContextStorage.defaultStorage().current();
       }
       return vertxCtx.getLocal(ACTIVE_CONTEXT);
     }


### PR DESCRIPTION
The VertxContextStorageProvider is chosen by OpenTelemetry via the service loader mechanism.

While it is mandatory to use context for storage of spans created on Vert.x threads, there may be parts of the application implemented without Vert.x.

In this case, the storage provider fails with NPE. Instead, it is better to fall back to the default storage mechanism, which uses thread local variables.