### PR TITLE
Deprecate tracing options constructors using a tracer instance

### DIFF
--- a/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
+++ b/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
@@ -6,6 +6,7 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.trace.*;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.HttpClient;
@@ -15,6 +16,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
 import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
+import io.vertx.tracing.opentelemetry.OpenTelemetryTracingFactory;
 
 @Source
 public class OpenTelemetryExamples {
@@ -28,11 +30,9 @@ public class OpenTelemetryExamples {
   }
 
   public void ex2(OpenTelemetry openTelemetry) {
-    Vertx vertx = Vertx.vertx(new VertxOptions()
-      .setTracingOptions(
-        new OpenTelemetryOptions(openTelemetry)
-      )
-    );
+    Vertx vertx = Vertx.builder()
+      .withTracer(new OpenTelemetryTracingFactory(openTelemetry))
+      .build();
   }
 
   public void ex3(Vertx vertx) {
@@ -68,6 +68,8 @@ public class OpenTelemetryExamples {
       .setPropagators(ContextPropagators.create(W3CTraceContextPropagator.getInstance()))
       .buildAndRegisterGlobal();
 
-    vertxOptions.setTracingOptions(new OpenTelemetryOptions(openTelemetry));
+    Vertx vertx = Vertx.builder()
+      .withTracer(new OpenTelemetryTracingFactory(openTelemetry))
+      .build();
   }
 }

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryOptions.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryOptions.java
@@ -14,6 +14,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.tracing.VertxTracer;
 import io.vertx.core.tracing.TracingOptions;
 
@@ -22,6 +23,11 @@ public class OpenTelemetryOptions extends TracingOptions {
 
   private OpenTelemetry openTelemetry;
 
+  /**
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withTracer(VertxTracerFactory)}
+   * and {@link OpenTelemetryTracer#OpenTelemetryTracer(OpenTelemetry)}.
+   */
+  @Deprecated
   public OpenTelemetryOptions(OpenTelemetry openTelemetry) {
     this.openTelemetry = openTelemetry;
     this.setFactory(OpenTelemetryTracingFactory.INSTANCE);

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
@@ -10,6 +10,8 @@
  */
 package io.vertx.tracing.opentelemetry;
 
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -19,15 +21,29 @@ public class OpenTelemetryTracingFactory implements VertxTracerFactory {
 
   static final OpenTelemetryTracingFactory INSTANCE = new OpenTelemetryTracingFactory();
 
+  private final OpenTelemetry openTelemetry;
+
+  public OpenTelemetryTracingFactory() {
+    this(null);
+  }
+
+  public OpenTelemetryTracingFactory(OpenTelemetry openTelemetry) {
+    this.openTelemetry = openTelemetry;
+  }
+
   @Override
   public VertxTracer<?, ?> tracer(final TracingOptions options) {
-    OpenTelemetryOptions openTelemetryOptions;
-    if (options instanceof OpenTelemetryOptions) {
-      openTelemetryOptions = (OpenTelemetryOptions) options;
+    if (openTelemetry != null) {
+      return new OpenTelemetryTracer(openTelemetry);
     } else {
-      openTelemetryOptions = new OpenTelemetryOptions(options.toJson());
+      OpenTelemetryOptions openTelemetryOptions;
+      if (options instanceof OpenTelemetryOptions) {
+        openTelemetryOptions = (OpenTelemetryOptions) options;
+      } else {
+        openTelemetryOptions = new OpenTelemetryOptions(options.toJson());
+      }
+      return openTelemetryOptions.buildTracer();
     }
-    return openTelemetryOptions.buildTracer();
   }
 
   @Override

--- a/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/OpenTelemetryIntegrationTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/OpenTelemetryIntegrationTest.java
@@ -64,7 +64,7 @@ public class OpenTelemetryIntegrationTest {
 
   @BeforeEach
   public void setUp() throws Exception {
-    vertx = Vertx.vertx(new VertxOptions().setTracingOptions(new OpenTelemetryOptions(otelTesting.getOpenTelemetry())));
+    vertx = Vertx.builder().withTracer(new OpenTelemetryTracingFactory(otelTesting.getOpenTelemetry())).build();
     textMapPropagator = otelTesting.getOpenTelemetry().getPropagators().getTextMapPropagator();
   }
 

--- a/vertx-opentracing/src/main/java/examples/OpenTracingExamples.java
+++ b/vertx-opentracing/src/main/java/examples/OpenTracingExamples.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
 import io.vertx.tracing.opentracing.OpenTracingOptions;
+import io.vertx.tracing.opentracing.OpenTracingTracerFactory;
 import io.vertx.tracing.opentracing.OpenTracingUtil;
 
 @Source
@@ -26,11 +27,9 @@ public class OpenTracingExamples {
   }
 
   public void ex2(Tracer tracer) {
-    Vertx vertx = Vertx.vertx(new VertxOptions()
-      .setTracingOptions(
-        new OpenTracingOptions(tracer)
-      )
-    );
+    Vertx vertx = Vertx.builder()
+      .withTracer(new OpenTracingTracerFactory(tracer))
+      .build();
   }
 
   public void ex3(Vertx vertx) {

--- a/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingOptions.java
+++ b/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingOptions.java
@@ -13,6 +13,7 @@ package io.vertx.tracing.opentracing;
 import io.opentracing.Tracer;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.tracing.TracingOptions;
 
 @DataObject
@@ -24,6 +25,11 @@ public class OpenTracingOptions extends TracingOptions {
     this.setFactory(OpenTracingTracerFactory.INSTANCE);
   }
 
+  /**
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withTracer(VertxTracerFactory)}
+   * and {@link OpenTracingTracer#OpenTracingTracer(boolean, Tracer)}.
+   */
+  @Deprecated
   public OpenTracingOptions(Tracer tracer) {
     this.tracer = tracer;
     this.setFactory(OpenTracingTracerFactory.INSTANCE);

--- a/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingTracerFactory.java
+++ b/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingTracerFactory.java
@@ -10,6 +10,7 @@
  */
 package io.vertx.tracing.opentracing;
 
+import io.opentracing.Tracer;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -19,15 +20,29 @@ public class OpenTracingTracerFactory implements VertxTracerFactory {
 
   static final OpenTracingTracerFactory INSTANCE = new OpenTracingTracerFactory();
 
+  private final Tracer tracer;
+
+  public OpenTracingTracerFactory() {
+    this(null);
+  }
+
+  public OpenTracingTracerFactory(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
   @Override
   public VertxTracer tracer(TracingOptions options) {
-    OpenTracingOptions openTracingOptions;
-    if (options instanceof OpenTracingOptions) {
-      openTracingOptions = (OpenTracingOptions) options;
+    if (tracer != null) {
+      return new OpenTracingTracer(false, tracer);
     } else {
-      openTracingOptions = new OpenTracingOptions(options.toJson());
+      OpenTracingOptions openTracingOptions;
+      if (options instanceof OpenTracingOptions) {
+        openTracingOptions = (OpenTracingOptions) options;
+      } else {
+        openTracingOptions = new OpenTracingOptions(options.toJson());
+      }
+      return openTracingOptions.buildTracer();
     }
-    return openTracingOptions.buildTracer();
   }
 
   @Override

--- a/vertx-opentracing/src/test/java/io/vertx/tracing/opentracing/OpenTracingTest.java
+++ b/vertx-opentracing/src/test/java/io/vertx/tracing/opentracing/OpenTracingTest.java
@@ -16,6 +16,7 @@ import io.opentracing.propagation.Format;
 import io.opentracing.propagation.TextMapAdapter;
 import io.opentracing.tag.Tags;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -47,7 +48,9 @@ public class OpenTracingTest {
   @Before
   public void before() {
     tracer = new MockTracer();
-    vertx = Vertx.vertx(new VertxOptions().setTracingOptions(new OpenTracingOptions(tracer)));
+    vertx = Vertx.builder()
+      .withTracer(new OpenTracingTracerFactory(tracer))
+      .build();
   }
 
   @After

--- a/vertx-zipkin/src/main/asciidoc/index.adoc
+++ b/vertx-zipkin/src/main/asciidoc/index.adoc
@@ -28,7 +28,7 @@ You can override the configuration of the HTTP sender with custom `HttpClientOpt
 {@link examples.ZipkinTracingExamples#ex3}
 ----
 
-Finally you can set a custom ZipKin `Tracing` allowing for greater control
+Finally, you can set a custom ZipKin `Tracing` allowing for greater control
 over the configuration.
 
 [source,$lang]

--- a/vertx-zipkin/src/main/java/examples/ZipkinTracingExamples.java
+++ b/vertx-zipkin/src/main/java/examples/ZipkinTracingExamples.java
@@ -2,6 +2,7 @@ package examples;
 
 import brave.Tracing;
 import io.vertx.core.Vertx;
+import io.vertx.core.VertxBuilder;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.http.HttpClient;
@@ -12,6 +13,7 @@ import io.vertx.core.net.KeyCertOptions;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
 import io.vertx.tracing.zipkin.HttpSenderOptions;
+import io.vertx.tracing.zipkin.ZipkinTracerFactory;
 import io.vertx.tracing.zipkin.ZipkinTracingOptions;
 
 @Source
@@ -47,11 +49,9 @@ public class ZipkinTracingExamples {
   }
 
   public void ex4(Tracing tracing) {
-    Vertx vertx = Vertx.vertx(new VertxOptions()
-      .setTracingOptions(
-        new ZipkinTracingOptions(tracing)
-      )
-    );
+    Vertx vertx = Vertx.builder()
+      .withTracer(new ZipkinTracerFactory(tracing))
+      .build();
   }
 
   public void ex5(Vertx vertx) {

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracer.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracer.java
@@ -28,6 +28,7 @@ import io.vertx.core.spi.observability.HttpResponse;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.tracing.TracingPolicy;
+import zipkin2.reporter.Sender;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -133,7 +134,7 @@ public class ZipkinTracer implements io.vertx.core.spi.tracing.VertxTracer<Span,
     }
   };
 
-  public VertxSender sender() {
+  public Sender sender() {
     return sender;
   }
 
@@ -162,7 +163,7 @@ public class ZipkinTracer implements io.vertx.core.spi.tracing.VertxTracer<Span,
   private final TraceContext.Extractor<HttpServerRequest> httpServerExtractor;
   private final Tracing tracing;
   private final boolean closeTracer;
-  private final VertxSender sender;
+  private final Sender sender;
   private final HttpServerHandler<HttpServerRequest, HttpServerRequest> httpServerHandler;
   private final HttpClientHandler<HttpRequest, HttpResponse> clientHandler;
   private final TraceContext.Extractor<Map<String, String>> mapExtractor;
@@ -171,7 +172,7 @@ public class ZipkinTracer implements io.vertx.core.spi.tracing.VertxTracer<Span,
     this(closeTracer, HttpTracing.newBuilder(tracing).build(), sender);
   }
 
-  public ZipkinTracer(boolean closeTracer, HttpTracing httpTracing, VertxSender sender) {
+  public ZipkinTracer(boolean closeTracer, HttpTracing httpTracing, Sender sender) {
     this.closeTracer = closeTracer;
     this.tracing = httpTracing.tracing();
     this.clientHandler = HttpClientHandler.create(httpTracing, HTTP_CLIENT_ADAPTER);

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracingOptions.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracingOptions.java
@@ -16,6 +16,7 @@ import brave.sampler.Sampler;
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.codegen.json.annotations.JsonGen;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.spi.VertxTracerFactory;
 import io.vertx.core.tracing.TracingOptions;
 import zipkin2.reporter.AsyncReporter;
 
@@ -34,11 +35,21 @@ public class ZipkinTracingOptions extends TracingOptions {
   private HttpSenderOptions senderOptions = new HttpSenderOptions();
   private HttpTracing httpTracing;
 
+  /**
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withTracer(VertxTracerFactory)}
+   * and {@link ZipkinTracerFactory#ZipkinTracerFactory(HttpTracing)}.
+   */
+  @Deprecated
   public ZipkinTracingOptions(HttpTracing httpTracing) {
     this.httpTracing = httpTracing;
     this.setFactory(ZipkinTracerFactory.INSTANCE);
   }
 
+  /**
+   * @deprecated instead use {@link io.vertx.core.VertxBuilder#withTracer(VertxTracerFactory)}
+   * and {@link ZipkinTracerFactory#ZipkinTracerFactory(Tracing)}.
+   */
+  @Deprecated
   public ZipkinTracingOptions(Tracing tracing) {
     this.httpTracing = HttpTracing.newBuilder(tracing).build();
     this.setFactory(ZipkinTracerFactory.INSTANCE);

--- a/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinHttpClientITTest.java
+++ b/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinHttpClientITTest.java
@@ -56,7 +56,7 @@ public class ZipkinHttpClientITTest extends ITHttpAsyncClient<HttpClient> {
   @Override
   protected HttpClient newClient(int port) {
     if (vertx == null) {
-      vertx = Vertx.vertx(new VertxOptions().setTracingOptions(new ZipkinTracingOptions(httpTracing)));
+      vertx = Vertx.builder().withTracer(new ZipkinTracerFactory(httpTracing)).build();
     }
     return vertx.createHttpClient(new HttpClientOptions()
       .setDefaultPort(port)

--- a/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinHttpServerITTest.java
+++ b/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinHttpServerITTest.java
@@ -35,7 +35,7 @@ public class ZipkinHttpServerITTest extends ITHttpServer implements Handler<Http
 
   @Override
   protected void init() throws Exception {
-    vertx = Vertx.vertx(new VertxOptions().setTracingOptions(new ZipkinTracingOptions(httpTracing)));
+    vertx = Vertx.builder().withTracer(new ZipkinTracerFactory(httpTracing)).build();
     server = vertx.createHttpServer(new HttpServerOptions().setTracingPolicy(TracingPolicy.ALWAYS)).requestHandler(this);
     CompletableFuture<Integer> fut = new CompletableFuture<>();
     server.listen(0, "localhost", ar -> {

--- a/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinTracingOptionsTest.java
+++ b/vertx-zipkin/src/test/java/io/vertx/tracing/zipkin/ZipkinTracingOptionsTest.java
@@ -37,7 +37,7 @@ public class ZipkinTracingOptionsTest {
     ZipkinTracingOptions options = new ZipkinTracingOptions().setSenderOptions(senderOptions);
     ZipkinTracerFactory factory = new ZipkinTracerFactory();
     ZipkinTracer tracer = factory.tracer(new TracingOptions(options.toJson()));
-    VertxSender sender = tracer.sender();
+    VertxSender sender = (VertxSender) tracer.sender();
     assertEquals(senderOptions.toJson(), sender.options().toJson());
   }
 


### PR DESCRIPTION
In favor of the VertxBuilder#withTracer along with tracer factory implementations.
