### PR TITLE
OpenTelemetry might not use the correct otel context when running in a worker thread

### DIFF
--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
@@ -22,6 +22,7 @@ import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapSetter;
 import io.vertx.core.Context;
 import io.vertx.core.internal.ContextInternal;
+import io.vertx.core.internal.VertxInternal;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -30,6 +31,8 @@ import io.vertx.tracing.opentelemetry.VertxContextStorageProvider.VertxContextSt
 
 import java.util.Map.Entry;
 import java.util.function.BiConsumer;
+
+import static io.vertx.tracing.opentelemetry.VertxContextStorageProvider.ACTIVE_CONTEXT;
 
 class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
 
@@ -58,8 +61,8 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
       return null;
     }
 
-    io.opentelemetry.context.Context otelCtx;
-    if ((otelCtx = VertxContextStorage.INSTANCE.current()) == null) {
+    io.opentelemetry.context.Context otelCtx = ((ContextInternal)context).getLocal(ACTIVE_CONTEXT);
+    if (otelCtx == null) {
       otelCtx = io.opentelemetry.context.Context.root();
     }
 
@@ -125,7 +128,7 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
       return null;
     }
 
-    io.opentelemetry.context.Context otelCtx = VertxContextStorage.INSTANCE.current();
+    io.opentelemetry.context.Context otelCtx = ((ContextInternal)context).getLocal(ACTIVE_CONTEXT);
 
     if (otelCtx == null) {
       if (!TracingPolicy.ALWAYS.equals(policy)) {

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/VertxContextStorageProvider.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/VertxContextStorageProvider.java
@@ -19,7 +19,7 @@ import io.vertx.core.internal.ContextInternal;
 
 public class VertxContextStorageProvider implements ContextStorageProvider {
 
-  private static final Object ACTIVE_CONTEXT = new Object();
+  public static final Object ACTIVE_CONTEXT = new Object();
 
   @Override
   public ContextStorage get() {

--- a/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/tests/OpenTelemetryIntegrationTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/tests/OpenTelemetryIntegrationTest.java
@@ -74,10 +74,11 @@ public class OpenTelemetryIntegrationTest {
   }
 
   private static Stream<Arguments> testTracingPolicyArgs() {
-    return Stream.of(TracingPolicy.PROPAGATE)
-      .flatMap(policy -> Stream.of(
-        Arguments.of(policy, true)
-      ));
+    return Stream.of(
+      Arguments.of(TracingPolicy.PROPAGATE, true),
+      Arguments.of(TracingPolicy.PROPAGATE, false),
+      Arguments.of(TracingPolicy.ALWAYS, true)
+    );
   }
 
   @ParameterizedTest

--- a/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/tests/OpenTelemetryTracingFactoryTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/tests/OpenTelemetryTracingFactoryTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -25,6 +26,7 @@ import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
 import io.vertx.tracing.opentelemetry.Operation;
+import io.vertx.tracing.opentelemetry.VertxContextStorageProvider;
 import io.vertx.tracing.opentelemetry.VertxContextStorageProvider.VertxContextStorage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -242,8 +244,8 @@ public class OpenTelemetryTracingFactoryTest {
   public void sendRequestShouldReturnSpanIfPolicyIsPropagateAndPreviousContextIsPresent(final Vertx vertx) {
     VertxTracer<Operation, Operation> tracer = new OpenTelemetryOptions(OpenTelemetry.noop()).buildTracer();
 
-    final Context ctx = vertx.getOrCreateContext();
-    VertxContextStorage.INSTANCE.attach(io.opentelemetry.context.Context.current());
+    final ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    ctx.putLocal(VertxContextStorageProvider.ACTIVE_CONTEXT, io.opentelemetry.context.Context.current());
 
     final Operation operation = tracer.sendRequest(
       ctx,


### PR DESCRIPTION
Motivation:
    
`OpenTelemetryTracer` obtains the active otel context from the thread local assocation, which returns null on a worker thread.
    
Changes:
    
`OpenTelemetryTracer` gets the active otel from the passed vertx context
