### PR TITLE
OpenTelemetry might not use the correct otel context when running in a worker thread

### DIFF
--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
@@ -58,7 +58,7 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
     }
 
     io.opentelemetry.context.Context otelCtx;
-    if ((otelCtx = VertxContextStorage.INSTANCE.current()) == null) {
+    if ((otelCtx = context.getLocal(VertxContextStorageProvider.ACTIVE_CONTEXT)) == null) {
       otelCtx = io.opentelemetry.context.Context.root();
     }
 
@@ -124,7 +124,7 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
       return null;
     }
 
-    io.opentelemetry.context.Context otelCtx = VertxContextStorage.INSTANCE.current();
+    io.opentelemetry.context.Context otelCtx = context.getLocal(VertxContextStorageProvider.ACTIVE_CONTEXT);
 
     if (otelCtx == null) {
       if (!TracingPolicy.ALWAYS.equals(policy)) {

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/VertxContextStorageProvider.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/VertxContextStorageProvider.java
@@ -19,7 +19,7 @@ import io.vertx.core.impl.ContextInternal;
 
 public class VertxContextStorageProvider implements ContextStorageProvider {
 
-  private static final Object ACTIVE_CONTEXT = new Object();
+  public static final Object ACTIVE_CONTEXT = new Object();
 
   @Override
   public ContextStorage get() {

--- a/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/OpenTelemetryIntegrationTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/OpenTelemetryIntegrationTest.java
@@ -74,10 +74,11 @@ public class OpenTelemetryIntegrationTest {
   }
 
   private static Stream<Arguments> testTracingPolicyArgs() {
-    return Stream.of(TracingPolicy.PROPAGATE)
-      .flatMap(policy -> Stream.of(
-        Arguments.of(policy, true)
-      ));
+    return Stream.of(
+      Arguments.of(TracingPolicy.PROPAGATE, true),
+      Arguments.of(TracingPolicy.PROPAGATE, false),
+      Arguments.of(TracingPolicy.ALWAYS, true)
+    );
   }
 
   @ParameterizedTest

--- a/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactoryTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactoryTest.java
@@ -18,6 +18,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.ContextPropagators;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.spi.tracing.SpanKind;
 import io.vertx.core.spi.tracing.TagExtractor;
 import io.vertx.core.spi.tracing.VertxTracer;
@@ -240,8 +241,8 @@ public class OpenTelemetryTracingFactoryTest {
   public void sendRequestShouldReturnSpanIfPolicyIsPropagateAndPreviousContextIsPresent(final Vertx vertx) {
     VertxTracer<Operation, Operation> tracer = new OpenTelemetryOptions(OpenTelemetry.noop()).buildTracer();
 
-    final Context ctx = vertx.getOrCreateContext();
-    VertxContextStorage.INSTANCE.attach(io.opentelemetry.context.Context.current());
+    final ContextInternal ctx = (ContextInternal) vertx.getOrCreateContext();
+    ctx.putLocal(VertxContextStorageProvider.ACTIVE_CONTEXT, io.opentelemetry.context.Context.current());
 
     final Operation operation = tracer.sendRequest(
       ctx,


### PR DESCRIPTION
Motivation:
    
`OpenTelemetryTracer` obtains the active otel context from the thread local assocation, which returns null on a worker thread.
    
Changes:
    
`OpenTelemetryTracer` gets the active otel from the passed vertx context
