### PR TITLE
Allow adding custom span attributes before the span is started

### DIFF
--- a/vertx-opentelemetry/src/main/asciidoc/index.adoc
+++ b/vertx-opentelemetry/src/main/asciidoc/index.adoc
@@ -80,3 +80,16 @@ The default sending policy is `PROPAGATE`, you can configure the policy with {@l
 ----
 {@link examples.OpenTelemetryExamples#ex6}
 ----
+
+== Customizing spans
+
+Custom attributes can be added to a span before it is started with a {@link io.vertx.tracing.opentelemetry.SpanCustomizer}.
+
+Since these attributes are set before the span is started, they are visible to the OpenTelemetry `Sampler` and can be used for head sampling decisions.
+
+[source,$lang]
+----
+{@link examples.OpenTelemetryExamples#ex8}
+----
+
+The customizer is invoked on the thread creating the span, often an event-loop thread: it must not block.

--- a/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
+++ b/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
 import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
@@ -59,6 +60,18 @@ public class OpenTelemetryExamples {
   public void ex6(Vertx vertx) {
     DeliveryOptions options = new DeliveryOptions().setTracingPolicy(TracingPolicy.ALWAYS);
     vertx.eventBus().send("the-address", "foo", options);
+  }
+
+  public void ex8(OpenTelemetry openTelemetry) {
+    Vertx vertx = Vertx
+      .builder()
+      .withTracer(new OpenTelemetryTracingFactory(openTelemetry)
+        .withSpanCustomizer((spanBuilder, request) -> {
+          if (request instanceof HttpRequest) {
+            spanBuilder.setAttribute("tenant.id", ((HttpRequest) request).headers().get("X-Tenant"));
+          }
+        }))
+      .build();
   }
 
   public void ex7() {

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
@@ -40,10 +40,16 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
 
   private final Tracer tracer;
   private final ContextPropagators propagators;
+  private final SpanCustomizer spanCustomizer;
 
   OpenTelemetryTracer(final OpenTelemetry openTelemetry) {
+    this(openTelemetry, null);
+  }
+
+  OpenTelemetryTracer(final OpenTelemetry openTelemetry, final SpanCustomizer spanCustomizer) {
     this.tracer = openTelemetry.getTracer("io.vertx");
     this.propagators = openTelemetry.getPropagators();
+    this.spanCustomizer = spanCustomizer;
   }
 
   @Override
@@ -167,6 +173,9 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
   private <T> Span reportTagsAndStart(SpanBuilder span, T obj, TagExtractor<T> tagExtractor, boolean client) {
     Attributes attributes = processTags(obj, tagExtractor, client);
     span.setAllAttributes(attributes);
+    if (spanCustomizer != null) {
+      spanCustomizer.customize(span, obj);
+    }
     return span.startSpan();
   }
 

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
@@ -24,6 +24,7 @@ public class OpenTelemetryTracingFactory implements VertxTracerFactory {
   static final ContextLocal<Context> ACTIVE_CONTEXT = ContextLocal.registerLocal(Context.class);
 
   private final OpenTelemetry openTelemetry;
+  private SpanCustomizer spanCustomizer;
 
   public OpenTelemetryTracingFactory() {
     this(null);
@@ -33,12 +34,23 @@ public class OpenTelemetryTracingFactory implements VertxTracerFactory {
     this.openTelemetry = openTelemetry;
   }
 
+  /**
+   * Set a customizer invoked before the tracer starts a span, e.g. to add custom attributes visible to the sampler.
+   *
+   * @param spanCustomizer the customizer, or {@code null} for none
+   * @return a reference to this, so the API can be used fluently
+   */
+  public OpenTelemetryTracingFactory withSpanCustomizer(SpanCustomizer spanCustomizer) {
+    this.spanCustomizer = spanCustomizer;
+    return this;
+  }
+
   @Override
   public VertxTracer<?, ?> tracer(final TracingOptions options) {
     if (openTelemetry != null) {
-      return new OpenTelemetryTracer(openTelemetry);
+      return new OpenTelemetryTracer(openTelemetry, spanCustomizer);
     } else {
-      return new OpenTelemetryTracer(GlobalOpenTelemetry.get());
+      return new OpenTelemetryTracer(GlobalOpenTelemetry.get(), spanCustomizer);
     }
   }
 

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/SpanCustomizer.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/SpanCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tracing.opentelemetry;
+
+import io.opentelemetry.api.trace.SpanBuilder;
+
+/**
+ * Customizes the spans created by the Vert.x OpenTelemetry tracer before they are started.
+ * <p>
+ * Attributes set on the {@link SpanBuilder} are visible to the {@code Sampler}, which makes head sampling
+ * decisions based on data extracted from the traced request possible.
+ * <p>
+ * The customizer is invoked on the thread creating the span, often an event-loop thread: implementations
+ * must not block.
+ */
+@FunctionalInterface
+public interface SpanCustomizer {
+
+  /**
+   * Invoked before a span is started.
+   *
+   * @param spanBuilder the builder of the span about to be started
+   * @param request the request object, e.g. {@link io.vertx.core.spi.observability.HttpRequest} for HTTP spans
+   *                or {@link io.vertx.core.eventbus.Message} for EventBus spans
+   */
+  void customize(SpanBuilder spanBuilder, Object request);
+
+}

--- a/vertx-opentelemetry/src/test/java/io/vertx/tests/opentelemetry/SpanCustomizerTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tests/opentelemetry/SpanCustomizerTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.data.LinkData;
+import io.opentelemetry.sdk.trace.samplers.Sampler;
+import io.opentelemetry.sdk.trace.samplers.SamplingResult;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
+import io.vertx.tracing.opentelemetry.OpenTelemetryTracingFactory;
+import io.vertx.tracing.opentelemetry.Operation;
+import io.vertx.tracing.opentelemetry.SpanCustomizer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@ExtendWith(VertxExtension.class)
+public class SpanCustomizerTest {
+
+  private static final AttributeKey<String> TENANT_ID = AttributeKey.stringKey("tenant.id");
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @SuppressWarnings("unchecked")
+  private static VertxTracer<Operation, Operation> tracer(OpenTelemetry openTelemetry, SpanCustomizer customizer) {
+    return (VertxTracer<Operation, Operation>) new OpenTelemetryTracingFactory(openTelemetry)
+      .withSpanCustomizer(customizer)
+      .tracer(new OpenTelemetryOptions());
+  }
+
+  @Test
+  public void customAttributesAreVisibleToTheSampler(Vertx vertx) {
+    AtomicReference<String> sampledValue = new AtomicReference<>();
+    Sampler sampler = new Sampler() {
+      @Override
+      public SamplingResult shouldSample(Context parentContext, String traceId, String name, io.opentelemetry.api.trace.SpanKind spanKind, Attributes attributes, List<LinkData> parentLinks) {
+        sampledValue.set(attributes.get(TENANT_ID));
+        return SamplingResult.recordAndSample();
+      }
+
+      @Override
+      public String getDescription() {
+        return "test-sampler";
+      }
+    };
+    OpenTelemetrySdk sdk = OpenTelemetrySdk.builder()
+      .setTracerProvider(SdkTracerProvider.builder().setSampler(sampler).build())
+      .build();
+    VertxTracer<Operation, Operation> tracer = tracer(sdk, (spanBuilder, request) -> spanBuilder.setAttribute(TENANT_ID, (String) request));
+
+    Operation operation = tracer.receiveRequest(
+      vertx.getOrCreateContext(),
+      SpanKind.RPC,
+      TracingPolicy.ALWAYS,
+      "the-tenant",
+      "GET",
+      Collections.emptyList(),
+      TagExtractor.empty()
+    );
+
+    assertThat(operation).isNotNull();
+    assertThat(sampledValue.get()).isEqualTo("the-tenant");
+  }
+
+  @Test
+  public void customizerIsAppliedToClientSpans(Vertx vertx) {
+    VertxTracer<Operation, Operation> tracer = tracer(otelTesting.getOpenTelemetry(), (spanBuilder, request) -> spanBuilder.setAttribute(TENANT_ID, "42"));
+
+    Operation operation = tracer.sendRequest(
+      vertx.getOrCreateContext(),
+      SpanKind.RPC,
+      TracingPolicy.ALWAYS,
+      "the-request",
+      "GET",
+      (k, v) -> {
+      },
+      TagExtractor.empty()
+    );
+
+    assertThat(operation).isNotNull();
+    tracer.receiveResponse(vertx.getOrCreateContext(), null, operation, null, TagExtractor.empty());
+
+    assertThat(otelTesting.getSpans())
+      .anySatisfy(span -> assertThat(span.getAttributes().get(TENANT_ID)).isEqualTo("42"));
+  }
+
+  @Test
+  public void customizerReceivesTheHttpServerRequest() throws Exception {
+    Vertx vertx = Vertx
+      .builder()
+      .withTracer(new OpenTelemetryTracingFactory(otelTesting.getOpenTelemetry())
+        .withSpanCustomizer((spanBuilder, request) -> {
+          if (request instanceof HttpRequest) {
+            spanBuilder.setAttribute(TENANT_ID, ((HttpRequest) request).headers().get("x-tenant"));
+          }
+        }))
+      .build();
+    try {
+      HttpServer server = vertx.createHttpServer(new HttpServerOptions().setTracingPolicy(TracingPolicy.ALWAYS))
+        .requestHandler(req -> req.response().end())
+        .listen(0)
+        .await(20, TimeUnit.SECONDS);
+
+      URL url = new URL("http://localhost:" + server.actualPort());
+      HttpURLConnection con = (HttpURLConnection) url.openConnection();
+      con.setRequestProperty("x-tenant", "acme");
+      assertThat(con.getResponseCode()).isEqualTo(200);
+
+      await().atMost(20, TimeUnit.SECONDS).untilAsserted(() ->
+        assertThat(otelTesting.getSpans())
+          .anySatisfy(span -> assertThat(span.getAttributes().get(TENANT_ID)).isEqualTo("acme")));
+    } finally {
+      vertx.close().await(20, TimeUnit.SECONDS);
+    }
+  }
+}


### PR DESCRIPTION
A `SpanCustomizer` can be set on the `OpenTelemetryTracingFactory` to customize spans before they are started. Since the customizer runs before `startSpan()`, attributes computed from the traced request are visible to the `Sampler`, enabling head sampling decisions based on request data.

Fixes #63