### PR TITLE
Support overriding the name of the spans created by the tracer

### DIFF
--- a/vertx-opentelemetry/src/main/asciidoc/index.adoc
+++ b/vertx-opentelemetry/src/main/asciidoc/index.adoc
@@ -80,3 +80,16 @@ The default sending policy is `PROPAGATE`, you can configure the policy with {@l
 ----
 {@link examples.OpenTelemetryExamples#ex6}
 ----
+
+== Span names
+
+By default, spans are named after the operation reported by Vert.x, e.g. the HTTP method for HTTP spans.
+
+A {@link io.vertx.tracing.opentelemetry.SpanNameProvider} can compute a more meaningful name from the traced request, keeping cardinality under control.
+
+[source,$lang]
+----
+{@link examples.OpenTelemetryExamples#ex9}
+----
+
+The provider is invoked on the thread creating the span, often an event-loop thread: it must not block.

--- a/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
+++ b/vertx-opentelemetry/src/main/java/examples/OpenTelemetryExamples.java
@@ -12,6 +12,7 @@ import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.spi.observability.HttpRequest;
 import io.vertx.core.tracing.TracingPolicy;
 import io.vertx.docgen.Source;
 import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
@@ -59,6 +60,19 @@ public class OpenTelemetryExamples {
   public void ex6(Vertx vertx) {
     DeliveryOptions options = new DeliveryOptions().setTracingPolicy(TracingPolicy.ALWAYS);
     vertx.eventBus().send("the-address", "foo", options);
+  }
+
+  public void ex9(OpenTelemetry openTelemetry) {
+    Vertx vertx = Vertx
+      .builder()
+      .withTracer(new OpenTelemetryTracingFactory(openTelemetry)
+        .withSpanNameProvider((operation, request) -> {
+          if (request instanceof HttpRequest) {
+            return operation + " " + ((HttpRequest) request).uri();
+          }
+          return operation;
+        }))
+      .build();
   }
 
   public void ex7() {

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracer.java
@@ -40,10 +40,16 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
 
   private final Tracer tracer;
   private final ContextPropagators propagators;
+  private final SpanNameProvider spanNameProvider;
 
   OpenTelemetryTracer(final OpenTelemetry openTelemetry) {
+    this(openTelemetry, null);
+  }
+
+  OpenTelemetryTracer(final OpenTelemetry openTelemetry, final SpanNameProvider spanNameProvider) {
     this.tracer = openTelemetry.getTracer("io.vertx");
     this.propagators = openTelemetry.getPropagators();
+    this.spanNameProvider = spanNameProvider;
   }
 
   @Override
@@ -76,7 +82,7 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
     io.opentelemetry.api.trace.SpanKind spanKind = SpanKind.RPC.equals(kind) ? io.opentelemetry.api.trace.SpanKind.SERVER : io.opentelemetry.api.trace.SpanKind.CONSUMER;
 
     SpanBuilder spanBuilder = tracer
-      .spanBuilder(operation)
+      .spanBuilder(spanName(operation, request))
       .setParent(otelCtx)
       .setSpanKind(spanKind);
 
@@ -139,7 +145,7 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
 
     io.opentelemetry.api.trace.SpanKind spanKind = SpanKind.RPC.equals(kind) ? io.opentelemetry.api.trace.SpanKind.CLIENT : io.opentelemetry.api.trace.SpanKind.PRODUCER;
 
-    SpanBuilder spanBuilder = tracer.spanBuilder(operation)
+    SpanBuilder spanBuilder = tracer.spanBuilder(spanName(operation, request))
       .setParent(otelCtx)
       .setSpanKind(spanKind);
 
@@ -161,6 +167,16 @@ class OpenTelemetryTracer implements VertxTracer<Operation, Operation> {
     if (operation != null) {
       end(operation, response, tagExtractor, failure, true);
     }
+  }
+
+  private String spanName(String operation, Object request) {
+    if (spanNameProvider != null) {
+      String name = spanNameProvider.spanName(operation, request);
+      if (name != null) {
+        return name;
+      }
+    }
+    return operation;
   }
 
   // tags need to be set before start, otherwise any sampler registered won't have access to it

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/OpenTelemetryTracingFactory.java
@@ -24,6 +24,7 @@ public class OpenTelemetryTracingFactory implements VertxTracerFactory {
   static final ContextLocal<Context> ACTIVE_CONTEXT = ContextLocal.registerLocal(Context.class);
 
   private final OpenTelemetry openTelemetry;
+  private SpanNameProvider spanNameProvider;
 
   public OpenTelemetryTracingFactory() {
     this(null);
@@ -33,12 +34,23 @@ public class OpenTelemetryTracingFactory implements VertxTracerFactory {
     this.openTelemetry = openTelemetry;
   }
 
+  /**
+   * Set a provider computing the name of the spans created by the tracer.
+   *
+   * @param spanNameProvider the provider, or {@code null} to use the operation name reported by Vert.x
+   * @return a reference to this, so the API can be used fluently
+   */
+  public OpenTelemetryTracingFactory withSpanNameProvider(SpanNameProvider spanNameProvider) {
+    this.spanNameProvider = spanNameProvider;
+    return this;
+  }
+
   @Override
   public VertxTracer<?, ?> tracer(final TracingOptions options) {
     if (openTelemetry != null) {
-      return new OpenTelemetryTracer(openTelemetry);
+      return new OpenTelemetryTracer(openTelemetry, spanNameProvider);
     } else {
-      return new OpenTelemetryTracer(GlobalOpenTelemetry.get());
+      return new OpenTelemetryTracer(GlobalOpenTelemetry.get(), spanNameProvider);
     }
   }
 

--- a/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/SpanNameProvider.java
+++ b/vertx-opentelemetry/src/main/java/io/vertx/tracing/opentelemetry/SpanNameProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tracing.opentelemetry;
+
+/**
+ * Provides the name of the spans created by the Vert.x OpenTelemetry tracer.
+ * <p>
+ * By default, spans are named after the operation reported by Vert.x, e.g. the HTTP method for HTTP spans.
+ * A provider can compute a more meaningful name from the traced request, keeping cardinality under control.
+ * <p>
+ * The provider is invoked on the thread creating the span, often an event-loop thread: implementations
+ * must not block.
+ */
+@FunctionalInterface
+public interface SpanNameProvider {
+
+  /**
+   * Invoked before a span is started.
+   *
+   * @param operation the operation name reported by Vert.x, e.g. the HTTP method for HTTP spans
+   * @param request the request object, e.g. {@link io.vertx.core.spi.observability.HttpRequest} for HTTP spans
+   *                or {@link io.vertx.core.eventbus.Message} for EventBus spans
+   * @return the span name, or {@code null} to use the operation name
+   */
+  String spanName(String operation, Object request);
+
+}

--- a/vertx-opentelemetry/src/test/java/io/vertx/tests/opentelemetry/SpanNameProviderTest.java
+++ b/vertx-opentelemetry/src/test/java/io/vertx/tests/opentelemetry/SpanNameProviderTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.opentelemetry;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.spi.observability.HttpRequest;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.spi.tracing.VertxTracer;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.tracing.opentelemetry.OpenTelemetryOptions;
+import io.vertx.tracing.opentelemetry.OpenTelemetryTracingFactory;
+import io.vertx.tracing.opentelemetry.Operation;
+import io.vertx.tracing.opentelemetry.SpanNameProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@ExtendWith(VertxExtension.class)
+public class SpanNameProviderTest {
+
+  @RegisterExtension
+  static final OpenTelemetryExtension otelTesting = OpenTelemetryExtension.create();
+
+  @SuppressWarnings("unchecked")
+  private static VertxTracer<Operation, Operation> tracer(OpenTelemetry openTelemetry, SpanNameProvider provider) {
+    return (VertxTracer<Operation, Operation>) new OpenTelemetryTracingFactory(openTelemetry)
+      .withSpanNameProvider(provider)
+      .tracer(new OpenTelemetryOptions());
+  }
+
+  @Test
+  public void providerOverridesServerSpanName(Vertx vertx) {
+    VertxTracer<Operation, Operation> tracer = tracer(otelTesting.getOpenTelemetry(), (operation, request) -> operation + " " + request);
+
+    Operation operation = tracer.receiveRequest(
+      vertx.getOrCreateContext(),
+      SpanKind.RPC,
+      TracingPolicy.ALWAYS,
+      "/the-route",
+      "GET",
+      Collections.emptyList(),
+      TagExtractor.empty()
+    );
+
+    assertThat(operation).isNotNull();
+    tracer.sendResponse(vertx.getOrCreateContext(), null, operation, null, TagExtractor.empty());
+
+    assertThat(otelTesting.getSpans())
+      .anySatisfy(span -> assertThat(span.getName()).isEqualTo("GET /the-route"));
+  }
+
+  @Test
+  public void providerOverridesClientSpanName(Vertx vertx) {
+    VertxTracer<Operation, Operation> tracer = tracer(otelTesting.getOpenTelemetry(), (operation, request) -> operation + " " + request);
+
+    Operation operation = tracer.sendRequest(
+      vertx.getOrCreateContext(),
+      SpanKind.RPC,
+      TracingPolicy.ALWAYS,
+      "/the-target",
+      "GET",
+      (k, v) -> {
+      },
+      TagExtractor.empty()
+    );
+
+    assertThat(operation).isNotNull();
+    tracer.receiveResponse(vertx.getOrCreateContext(), null, operation, null, TagExtractor.empty());
+
+    assertThat(otelTesting.getSpans())
+      .anySatisfy(span -> assertThat(span.getName()).isEqualTo("GET /the-target"));
+  }
+
+  @Test
+  public void operationIsUsedWhenProviderReturnsNull(Vertx vertx) {
+    VertxTracer<Operation, Operation> tracer = tracer(otelTesting.getOpenTelemetry(), (operation, request) -> null);
+
+    Operation operation = tracer.receiveRequest(
+      vertx.getOrCreateContext(),
+      SpanKind.RPC,
+      TracingPolicy.ALWAYS,
+      "/the-route",
+      "GET",
+      Collections.emptyList(),
+      TagExtractor.empty()
+    );
+
+    assertThat(operation).isNotNull();
+    tracer.sendResponse(vertx.getOrCreateContext(), null, operation, null, TagExtractor.empty());
+
+    assertThat(otelTesting.getSpans())
+      .anySatisfy(span -> assertThat(span.getName()).isEqualTo("GET"));
+  }
+
+  @Test
+  public void providerReceivesTheHttpServerRequest() throws Exception {
+    Vertx vertx = Vertx
+      .builder()
+      .withTracer(new OpenTelemetryTracingFactory(otelTesting.getOpenTelemetry())
+        .withSpanNameProvider((operation, request) -> {
+          if (request instanceof HttpRequest) {
+            return operation + " " + ((HttpRequest) request).uri();
+          }
+          return operation;
+        }))
+      .build();
+    try {
+      HttpServer server = vertx.createHttpServer(new HttpServerOptions().setTracingPolicy(TracingPolicy.ALWAYS))
+        .requestHandler(req -> req.response().end())
+        .listen(0)
+        .await(20, TimeUnit.SECONDS);
+
+      URL url = new URL("http://localhost:" + server.actualPort() + "/users");
+      HttpURLConnection con = (HttpURLConnection) url.openConnection();
+      assertThat(con.getResponseCode()).isEqualTo(200);
+
+      await().atMost(20, TimeUnit.SECONDS).untilAsserted(() ->
+        assertThat(otelTesting.getSpans())
+          .anySatisfy(span -> assertThat(span.getName()).isEqualTo("GET /users")));
+    } finally {
+      vertx.close().await(20, TimeUnit.SECONDS);
+    }
+  }
+}


### PR DESCRIPTION
A `SpanNameProvider` can be set on the `OpenTelemetryTracingFactory` to compute span names from the traced request instead of the operation reported by Vert.x (e.g. `GET /users` instead of `GET`), as recommended by the OpenTelemetry HTTP semantic conventions. Returning `null` falls back to the operation name.

Fixes #59