### PR TITLE
Support reporting Zipkin spans with another transport than HTTP

### DIFF
--- a/vertx-zipkin/src/main/asciidoc/index.adoc
+++ b/vertx-zipkin/src/main/asciidoc/index.adoc
@@ -28,6 +28,15 @@ You can override the configuration of the HTTP sender with custom `HttpClientOpt
 {@link examples.ZipkinTracingExamples#ex3}
 ----
 
+Spans can be reported with another transport than HTTP, e.g. Kafka or ActiveMQ: set a span handler
+created with any Zipkin `BytesMessageSender`. The corresponding sender library must be added
+to the classpath, and the handler must be closed when it is not needed anymore.
+
+[source,$lang]
+----
+{@link examples.ZipkinTracingExamples#ex8}
+----
+
 Finally, you can set a custom ZipKin `Tracing` allowing for greater control
 over the configuration.
 

--- a/vertx-zipkin/src/main/java/examples/ZipkinTracingExamples.java
+++ b/vertx-zipkin/src/main/java/examples/ZipkinTracingExamples.java
@@ -14,6 +14,8 @@ import io.vertx.docgen.Source;
 import io.vertx.tracing.zipkin.HttpSenderOptions;
 import io.vertx.tracing.zipkin.ZipkinTracerFactory;
 import io.vertx.tracing.zipkin.ZipkinTracingOptions;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
 
 @Source
 public class ZipkinTracingExamples {
@@ -45,6 +47,14 @@ public class ZipkinTracingExamples {
             .setKeyCertOptions(sslOptions))
       )
     );
+  }
+
+  public void ex8(BytesMessageSender sender) {
+    Vertx vertx = Vertx
+      .builder()
+      .withTracer(new ZipkinTracerFactory()
+        .withSpanHandler(AsyncZipkinSpanHandler.create(sender)))
+      .build();
   }
 
   public void ex4(Tracing tracing) {

--- a/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracerFactory.java
+++ b/vertx-zipkin/src/main/java/io/vertx/tracing/zipkin/ZipkinTracerFactory.java
@@ -12,6 +12,7 @@ package io.vertx.tracing.zipkin;
 
 import brave.Span;
 import brave.Tracing;
+import brave.handler.SpanHandler;
 import brave.http.HttpTracing;
 import brave.propagation.TraceContext;
 import brave.sampler.Sampler;
@@ -30,6 +31,7 @@ public class ZipkinTracerFactory implements VertxTracerFactory {
 
   private final Sampler sampler;
   private final HttpTracing httpTracing;
+  private SpanHandler spanHandler;
 
   public ZipkinTracerFactory() {
     this(null, null);
@@ -57,6 +59,20 @@ public class ZipkinTracerFactory implements VertxTracerFactory {
     }
   }
 
+  /**
+   * Set a handler reporting the finished spans instead of sending them to Zipkin over HTTP, e.g. a
+   * {@link AsyncZipkinSpanHandler} created with any {@code BytesMessageSender} such as a Kafka or ActiveMQ sender.
+   * <p>
+   * The handler is not closed when Vert.x closes: the caller remains responsible for its lifecycle.
+   *
+   * @param spanHandler the handler, or {@code null} to send spans to Zipkin over HTTP
+   * @return a reference to this, so the API can be used fluently
+   */
+  public ZipkinTracerFactory withSpanHandler(SpanHandler spanHandler) {
+    this.spanHandler = spanHandler;
+    return this;
+  }
+
   @Override
   public ZipkinTracer tracer(TracingOptions options) {
     if (httpTracing != null) {
@@ -68,17 +84,21 @@ public class ZipkinTracerFactory implements VertxTracerFactory {
     } else {
       zipkinOptions = new ZipkinTracingOptions(options.toJson());
     }
+    assert sampler != null : "sampler shouldn't be null when httpTracing is null";
+    String localServiceName = zipkinOptions.getServiceName();
+    Tracing.Builder builder = Tracing
+      .newBuilder()
+      .supportsJoin(zipkinOptions.isSupportsJoin())
+      .localServiceName(localServiceName)
+      .sampler(sampler);
+    if (spanHandler != null) {
+      return new ZipkinTracer(true, builder.addSpanHandler(spanHandler).build(), null);
+    }
     HttpSenderOptions senderOptions = zipkinOptions.getSenderOptions();
     if (senderOptions != null) {
-      String localServiceName = zipkinOptions.getServiceName();
       VertxSender sender = new VertxSender(senderOptions);
-      assert sampler != null : "sampler shouldn't be null when httpTracing is null";
-      Tracing tracing = Tracing
-        .newBuilder()
-        .supportsJoin(zipkinOptions.isSupportsJoin())
-        .localServiceName(localServiceName)
+      Tracing tracing = builder
         .addSpanHandler(AsyncZipkinSpanHandler.create(sender))
-        .sampler(sampler)
         .build();
       return new ZipkinTracer(true, tracing, sender);
     } else {

--- a/vertx-zipkin/src/test/java/io/vertx/tests/zipkin/SpanHandlerTest.java
+++ b/vertx-zipkin/src/test/java/io/vertx/tests/zipkin/SpanHandlerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.zipkin;
+
+import brave.handler.MutableSpan;
+import brave.handler.SpanHandler;
+import brave.propagation.TraceContext;
+import io.vertx.core.Vertx;
+import io.vertx.core.spi.tracing.SpanKind;
+import io.vertx.core.spi.tracing.TagExtractor;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.tracing.zipkin.ZipkinTracer;
+import io.vertx.tracing.zipkin.ZipkinTracerFactory;
+import io.vertx.tracing.zipkin.ZipkinTracingOptions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.Assert.*;
+
+public class SpanHandlerTest {
+
+  private Vertx vertx;
+
+  @Before
+  public void before() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void after() throws Exception {
+    vertx.close().await();
+  }
+
+  private static class CapturingSpanHandler extends SpanHandler {
+
+    final List<MutableSpan> reported = new CopyOnWriteArrayList<>();
+
+    @Override
+    public boolean end(TraceContext context, MutableSpan span, Cause cause) {
+      reported.add(span);
+      return true;
+    }
+  }
+
+  @Test
+  public void testSpansAreReportedToTheSpanHandler() {
+    CapturingSpanHandler handler = new CapturingSpanHandler();
+    ZipkinTracer tracer = new ZipkinTracerFactory()
+      .withSpanHandler(handler)
+      .tracer(new ZipkinTracingOptions().setServiceName("the-service"));
+
+    brave.Span span = tracer.receiveRequest(
+      vertx.getOrCreateContext(),
+      SpanKind.MESSAGING,
+      TracingPolicy.ALWAYS,
+      null,
+      "the-operation",
+      Collections.emptyList(),
+      TagExtractor.empty()
+    );
+    tracer.sendResponse(vertx.getOrCreateContext(), null, span, null, TagExtractor.empty());
+    tracer.close();
+
+    assertNull(tracer.sender());
+    assertEquals(1, handler.reported.size());
+    assertEquals("the-operation", handler.reported.get(0).name());
+    assertEquals("the-service", handler.reported.get(0).localServiceName());
+  }
+}


### PR DESCRIPTION
A `SpanHandler` can be set on the `ZipkinTracerFactory` to report the finished spans instead of the Vert.x HTTP sender, e.g. an `AsyncZipkinSpanHandler` created with any `BytesMessageSender` (Kafka, ActiveMQ, ...), while the tracing options still configure the service name, join support and sampler. This keeps the module free of transport dependencies: the sender library is provided by the application.

Fixes #19