### PR TITLE
OpenTracing: keep the span attached to the duplicated context after it finishes

### DIFF
--- a/vertx-opentracing/pom.xml
+++ b/vertx-opentracing/pom.xml
@@ -43,6 +43,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>5.14.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>

--- a/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingTracer.java
+++ b/vertx-opentracing/src/main/java/io/vertx/tracing/opentracing/OpenTracingTracer.java
@@ -99,7 +99,12 @@ public class OpenTracingTracer implements io.vertx.core.spi.tracing.VertxTracer<
   public <R> void sendResponse(
     Context context, R response, Span span, Throwable failure, TagExtractor<R> tagExtractor) {
     if (span != null) {
-      ((ContextInternal) context).removeLocal(ACTIVE_SPAN, CONCURRENT);
+      ContextInternal ctx = (ContextInternal) context;
+      if (!ctx.isDuplicate()) {
+        // the duplicated context is scoped to this request or message: keep the span attached
+        // so that spans created by tasks scheduled from the handler remain in the trace after it finishes
+        ctx.removeLocal(ACTIVE_SPAN, CONCURRENT);
+      }
       if (failure != null) {
         reportFailure(span, failure);
       }

--- a/vertx-opentracing/src/test/java/io/vertx/tests/opentracing/AsyncTaskTracingTest.java
+++ b/vertx-opentracing/src/test/java/io/vertx/tests/opentracing/AsyncTaskTracingTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2011-2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+package io.vertx.tests.opentracing;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.http.HttpClient;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.http.RequestOptions;
+import io.vertx.core.tracing.TracingPolicy;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tracing.opentracing.OpenTracingTracerFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Tasks scheduled from a handler keep running on the request or message scoped Vert.x context after the
+ * server or consumer span has finished: spans they create must remain part of the trace.
+ */
+@RunWith(VertxUnitRunner.class)
+public class AsyncTaskTracingTest {
+
+  private static final String ADDRESS = "the-address";
+
+  private MockTracer tracer;
+  private Vertx vertx;
+  private HttpClient client;
+  private HttpServer server;
+
+  @Before
+  public void before() throws Exception {
+    tracer = new MockTracer();
+    vertx = Vertx.builder().withTracer(new OpenTracingTracerFactory(tracer)).build();
+    server = vertx.createHttpServer(new HttpServerOptions().setTracingPolicy(TracingPolicy.IGNORE))
+      .requestHandler(req -> req.response().end())
+      .listen(0)
+      .await(20, TimeUnit.SECONDS);
+    client = vertx.createHttpClient();
+  }
+
+  @After
+  public void after(TestContext context) {
+    client.close();
+    vertx.close().onComplete(context.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testClientCallAfterPublishConsumerHandlerReturnsJoinsTheTrace(TestContext ctx) throws Exception {
+    vertx.eventBus().consumer(ADDRESS, msg ->
+      // runs after the handler has returned and the consumer span has finished
+      vertx.runOnContext(v ->
+        client.request(new RequestOptions().setMethod(HttpMethod.GET).setHost("localhost").setPort(server.actualPort()))
+          .compose(HttpClientRequest::send)
+          .compose(HttpClientResponse::body)
+      )
+    ).completion().await(20, TimeUnit.SECONDS);
+
+    vertx.getOrCreateContext().runOnContext(v ->
+      vertx.eventBus().publish(ADDRESS, "ping", new DeliveryOptions().setTracingPolicy(TracingPolicy.ALWAYS))
+    );
+
+    long now = System.currentTimeMillis();
+    while (true) {
+      List<MockSpan> spans = tracer.finishedSpans();
+      MockSpan consumerSpan = spans.stream()
+        .filter(span -> "publish".equals(span.operationName())
+          && Tags.SPAN_KIND_SERVER.equals(span.tags().get(Tags.SPAN_KIND.getKey())))
+        .findFirst()
+        .orElse(null);
+      List<MockSpan> clientSpans = spans.stream()
+        .filter(span -> "GET".equals(span.operationName())
+          && Tags.SPAN_KIND_CLIENT.equals(span.tags().get(Tags.SPAN_KIND.getKey())))
+        .collect(Collectors.toList());
+      if (consumerSpan != null && !clientSpans.isEmpty()) {
+        for (MockSpan clientSpan : clientSpans) {
+          // the default HTTP client policy is PROPAGATE: the span only exists if the trace was propagated
+          ctx.assertEquals(consumerSpan.context().traceId(), clientSpan.context().traceId());
+        }
+        break;
+      }
+      ctx.assertTrue(System.currentTimeMillis() - now < 10_000L, "Expected a client span joining the consumer trace");
+      Thread.sleep(10);
+    }
+  }
+}


### PR DESCRIPTION
Applies the same fix as #104 to the OpenTracing tracer: the active span local was removed from the Vert.x context when the server or consumer span finished, so spans created by tasks scheduled from the handler (e.g. in an event bus `publish` consumer) could not join the trace anymore. Since requests and messages are dispatched on a duplicated context scoped to their lifecycle, the span can remain attached without leaking.

While adding the regression test I noticed Surefire silently runs no test in this module: the tests are written with JUnit 4 but only the Jupiter engine is on the test classpath. The first commit adds the vintage engine (aligned with the JUnit platform version brought in by vertx-junit5), which restores execution of the 30 existing tests — they all pass.